### PR TITLE
Better handling of type arrays in uploaded query graphs

### DIFF
--- a/frontend/src/components/shared/graphs/QuestionGraphView.jsx
+++ b/frontend/src/components/shared/graphs/QuestionGraphView.jsx
@@ -141,7 +141,12 @@ export default function QuestionGraphView(props) {
     const nodeTypeColorMap = getNodeTypeColorMap(config.concepts);
 
     graph.nodes.forEach((n) => {
-      const backgroundColor = nodeTypeColorMap(n.type);
+      let backgroundColor;
+      if (Array.isArray(n.type)) {
+        backgroundColor = nodeTypeColorMap(n.type[0]);
+      } else {
+        backgroundColor = nodeTypeColorMap(n.type);
+      }
       n.color = {
         border: '#000000',
         background: backgroundColor,

--- a/frontend/src/pages/question/panels/EdgePanel.jsx
+++ b/frontend/src/pages/question/panels/EdgePanel.jsx
@@ -59,11 +59,19 @@ export default function EdgePanel(props) {
       return null;
     }
 
-    const sourceNodeTypeHierarchy = biolinkUtils.getHierarchy(biolink, sourceNode.type);
-    const targetNodeTypeHierarchy = biolinkUtils.getHierarchy(biolink, targetNode.type);
+    // For each type listed in the node get the type hierarchy
+    const sourceNodeTypeHierarchies = sourceNode.type.map(
+      (t) => biolinkUtils.getHierarchy(biolink, t),
+    );
+    const targetNodeTypeHierarchies = targetNode.type.map(
+      (t) => biolinkUtils.getHierarchy(biolink, t),
+    );
+
+    // Show all predicates where the domain matches any type in the source node,
+    // and where the range matches any type in the target node
     return predicateList.filter(
-      (p) => sourceNodeTypeHierarchy.includes(p.domain) &&
-               targetNodeTypeHierarchy.includes(p.range),
+      (p) => sourceNodeTypeHierarchies.some((h) => h.includes(p.domain)) &&
+             targetNodeTypeHierarchies.some((h) => h.includes(p.range)),
     );
   }
 

--- a/frontend/src/pages/question/panels/EdgePanel.jsx
+++ b/frontend/src/pages/question/panels/EdgePanel.jsx
@@ -59,19 +59,12 @@ export default function EdgePanel(props) {
       return null;
     }
 
-    // For each type listed in the node get the type hierarchy
-    const sourceNodeTypeHierarchies = sourceNode.type.map(
-      (t) => biolinkUtils.getHierarchy(biolink, t),
-    );
-    const targetNodeTypeHierarchies = targetNode.type.map(
-      (t) => biolinkUtils.getHierarchy(biolink, t),
-    );
+    const sourceNodeTypeHierarchy = biolinkUtils.getHierarchy(biolink, sourceNode.type[0]);
+    const targetNodeTypeHierarchy = biolinkUtils.getHierarchy(biolink, targetNode.type[0]);
 
-    // Show all predicates where the domain matches any type in the source node,
-    // and where the range matches any type in the target node
     return predicateList.filter(
-      (p) => sourceNodeTypeHierarchies.some((h) => h.includes(p.domain)) &&
-             targetNodeTypeHierarchies.some((h) => h.includes(p.range)),
+      (p) => sourceNodeTypeHierarchy.includes(p.domain) &&
+               targetNodeTypeHierarchy.includes(p.range),
     );
   }
 

--- a/frontend/src/pages/question/questionBuilder/useNewQuestionPanel.js
+++ b/frontend/src/pages/question/questionBuilder/useNewQuestionPanel.js
@@ -53,7 +53,12 @@ export default function useNewQuestionPanel() {
   function initializeNodeOrEdge() {
     if (panelInfo.type === 'node') {
       if (panelInfo.id) { // load node from query graph
-        const nodeSeed = query_graph.nodes[panelInfo.id];
+        const nodeSeed = { ...query_graph.nodes[panelInfo.id] };
+        // Convert array of types to string before seeding
+        // panel
+        if (Array.isArray(nodeSeed.type)) {
+          [nodeSeed.type] = nodeSeed.type;
+        }
         setName(panelInfo.id);
         node.initialize(nodeSeed);
       } else { // new node
@@ -138,6 +143,11 @@ export default function useNewQuestionPanel() {
       const new_node = {
         type: node.type,
       };
+      // If node type isn't an array, convert to one
+      if (new_node.type && !Array.isArray(new_node.type)) {
+        new_node.type = [new_node.type];
+      }
+
       if (node.curie) {
         new_node.curie = node.curie;
       }

--- a/frontend/src/utils/queryGraph.js
+++ b/frontend/src/utils/queryGraph.js
@@ -80,7 +80,10 @@ const convert = {
     const internalRepresentation = {};
     internalRepresentation.nodes = listWithIdsToDict(q.nodes);
     internalRepresentation.edges = listWithIdsToDict(q.edges);
+
     Object.values(internalRepresentation.nodes).forEach(standardizeCuries);
+    Object.values(internalRepresentation.nodes).forEach(standardizeType);
+
     Object.values(internalRepresentation.edges).forEach(standardizeType);
     return internalRepresentation;
   },
@@ -88,7 +91,10 @@ const convert = {
     const reasonerRepresentation = {};
     reasonerRepresentation.nodes = dictToListWithIds(q.nodes);
     reasonerRepresentation.edges = dictToListWithIds(q.edges);
+
     reasonerRepresentation.nodes.forEach(pruneCuries);
+    reasonerRepresentation.nodes.forEach(pruneTypes);
+
     reasonerRepresentation.edges.forEach(pruneTypes);
     return reasonerRepresentation;
   },


### PR DESCRIPTION
Improved how we handle types that are stored as a list. With this PR, if a query graph is uploaded and then downloaded again with a type list for a node then the type will remain as a list and not be modified. We still overwrite the type list if the user tries to modify the node within the NodePanel.