### PR TITLE
Remove 404 error handling in queryDispatcher

### DIFF
--- a/frontend/queryDispatcher/index.js
+++ b/frontend/queryDispatcher/index.js
@@ -3,12 +3,4 @@ const routes = require('./routes');
 
 router.use('/api', routes);
 
-router.use((err, req, res, next) => {
-  res.status(500).send({ status: 'error', message: 'QueryDispatcher Server Error' });
-});
-
-router.use((req, res, next) => {
-  res.status(404).send({ status: 'error', message: 'QueryDispatcher Not Found' });
-});
-
 module.exports = router;


### PR DESCRIPTION
Reverting previous change to better handle queryDispatcher errors with a 404. This will become an issue to improve later.