### PR TITLE
Fix bug with CurieConceptSelector

### DIFF
--- a/frontend/src/components/shared/curies/CurieConceptSelector.jsx
+++ b/frontend/src/components/shared/curies/CurieConceptSelector.jsx
@@ -116,7 +116,10 @@ export default function CurieConceptSelector({
   }
 
   const nRows = concepts.length + curies.length;
-  const showOptions = searchTerm && !selection.type;
+
+  // Show options if there is no curie or type (valid selection) AND we have a search term
+  const showOptions = searchTerm && !selection.type && !selection.curie.length;
+
   const isEmpty = nRows === 0;
 
   const rowHeight = 50;
@@ -134,7 +137,7 @@ export default function CurieConceptSelector({
             inputRef={(ref) => { inputRef.current = ref; }}
             onChange={(e) => updateSearchTerm(e.target.value)}
           />
-          {!showOptions && selection.curie.length > 0 && (
+          {!!selection.curie.length && (
             <InputGroup.Addon>
               {selection.curie[0]}
             </InputGroup.Addon>

--- a/frontend/src/pages/question/questionBuilder/useNode.js
+++ b/frontend/src/pages/question/questionBuilder/useNode.js
@@ -4,7 +4,6 @@ import config from '@/config.json';
 import entityNameDisplay from '@/utils/entityNameDisplay';
 
 export default function useNodePanels() {
-  const [id, setId] = useState(null);
   const [type, setType] = useState('');
   const [name, setName] = useState('');
   const [searchTerm, setSearchTerm] = useState('');
@@ -17,7 +16,6 @@ export default function useNodePanels() {
   const [loading, setLoading] = useState(false);
 
   function reset() {
-    setId(null);
     setType('');
     setName('');
     setSearchTerm('');
@@ -32,7 +30,6 @@ export default function useNodePanels() {
 
   function initialize(seed) {
     reset();
-    setId(seed.id || null);
     setType(seed.type || '');
     setName(seed.name || seed.type || '');
     setSearchTerm(seed.name || seed.type || '');
@@ -77,7 +74,7 @@ export default function useNodePanels() {
     setFilteredConcepts(newFilteredConcepts);
   }
 
-  const isValid = !!id || !!type;
+  const isValid = !!type || (curie && curie.length);
 
   return {
     name,
@@ -87,7 +84,6 @@ export default function useNodePanels() {
     setConcepts,
     setLoading,
     setSearchTerm,
-    id,
     filteredConcepts,
     curie,
     curies,


### PR DESCRIPTION
To reproduce issue:

1. Visit http://robokop.renci.org:7080/simple/question
1. Blank question
1. New node
1. Search for "Coronavirus"
1. Click select
1. Nothing happens

This is caused by the code not considering a selection valid if it does not have a type. This pull request updates the definition of a valid type to include a curie.