### PR TITLE
remove predicate filtering by sub/obj domain/range

### DIFF
--- a/src/pages/queryBuilder/textEditor/textEditorRow/PredicateSelector.jsx
+++ b/src/pages/queryBuilder/textEditor/textEditorRow/PredicateSelector.jsx
@@ -46,10 +46,7 @@ export default function PredicateSelector({ id }) {
       return null;
     }
 
-    return biolink.predicates.filter(
-      (p) => subjectNodeCategoryHierarchy.includes(p.domain) &&
-             objectNodeCategoryHierarchy.includes(p.range),
-    ).map((p) => p.predicate);
+    return biolink.predicates.map(({ predicate }) => predicate);
   }
 
   const filteredPredicateList = useMemo(

--- a/src/stores/useBiolinkModel.js
+++ b/src/stores/useBiolinkModel.js
@@ -13,16 +13,29 @@ export default function useBiolinkModel() {
   const [ancestorsMap, setAncestorsMap] = useState([]);
   const colorMap = useCallback(getNodeCategoryColorMap(hierarchies), [hierarchies]);
 
+  function checkIfDescendantOfRelatedTo([name, slot]) {
+    let currentName = name;
+    let current = slot;
+    while (current.is_a) {
+      currentName = current.is_a;
+      current = biolinkModel.slots[current.is_a];
+    }
+    return currentName === 'related to';
+  }
+
   /**
    * Get a list of all predicates in the biolink model
    * @returns {object[]} list of predicate objects
    */
   function getEdgePredicates() {
-    const newPredicates = Object.entries(biolinkModel.slots).map(([identifier, predicate]) => ({
-      predicate: strings.edgeFromBiolink(identifier),
-      domain: strings.nodeFromBiolink(predicate.domain),
-      range: strings.nodeFromBiolink(predicate.range),
-    }));
+    const newPredicates =
+      Object.entries(biolinkModel.slots)
+        .filter(checkIfDescendantOfRelatedTo)
+        .map(([identifier, predicate]) => ({
+          predicate: strings.edgeFromBiolink(identifier),
+          domain: strings.nodeFromBiolink(predicate.domain),
+          range: strings.nodeFromBiolink(predicate.range),
+        }));
     return newPredicates;
   }
 


### PR DESCRIPTION
This removes the filtering on the predicate selector. I.e., it should now display all of the predicates available in the biolink model. 