### PR TITLE
Fixing missing arrows in answer graph

### DIFF
--- a/src/utils/d3/graph.js
+++ b/src/utils/d3/graph.js
@@ -156,7 +156,7 @@ function isInside(x, y, cx, cy, r) {
  * @returns {str} url(#arrow) or empty string
  */
 function shouldShowArrow(edge) {
-  return edge.predicates && edge.predicates.findIndex((p) => p !== 'biolink:related_to') > -1;
+  return (edge.predicates && edge.predicates.findIndex((p) => p !== 'biolink:related_to') > -1) || (edge.predicate && edge.predicate !== 'biolink:related_to');
 }
 
 /**


### PR DESCRIPTION
Fixed arrows not showing up in the Answer Explorer

![image](https://github.com/user-attachments/assets/52ae9e22-298a-4d35-ac65-3b7d5931dae4)
