### PR TITLE
ENH: Making edges less bouncy and fitting node names in answer graphs

### DIFF
--- a/src/pages/answer/resultsTable/ResultExplorer.jsx
+++ b/src/pages/answer/resultsTable/ResultExplorer.jsx
@@ -125,7 +125,7 @@ export default function ResultExplorer({ answerStore }) {
   useEffect(() => {
     simulation.current = d3.forceSimulation()
       .force('collide', d3.forceCollide().radius(nodeRadius * 2))
-      .force('link', d3.forceLink().id((d) => d.id).distance(175).strength(1))
+      .force('link', d3.forceLink().id((d) => d.id).distance(175).strength(0))
       .on('tick', ticked);
   }, []);
 
@@ -199,14 +199,44 @@ export default function ResultExplorer({ answerStore }) {
               .on('click', function () {
                 handleClickNode(d3.select(this).datum());
               }))
-            .call((n) => n.append('text')
-              .attr('class', 'result_node_label')
-              .style('pointer-events', 'none')
-              .attr('text-anchor', 'middle')
-              .style('font-weight', 600)
-              .attr('alignment-baseline', 'middle')
-              .text((d) => d.name)
-              .each(graphUtils.ellipsisOverflow)),
+              .call((n) => {
+                const textGroup = n.append('text')
+                  .attr('class', 'result_node_label')
+                  .style('pointer-events', 'none')
+                  .attr('text-anchor', 'middle')
+                  .style('font-weight', 600)
+                  .attr('alignment-baseline', 'middle')
+                  .style('font-size', (d) => {
+                    const maxFontSize = nodeRadius * 0.4;
+                    const minFontSize = 8;
+                    const textLength = d.name.length;
+                    return `${Math.max(minFontSize, Math.min(maxFontSize, nodeRadius / Math.sqrt(textLength)))}px`;
+                  });
+                textGroup.each(function (d) {
+                  const words = d.name.split(' ');
+                  const textElement = d3.select(this);
+                  if (words.length === 1 || d.name.length < 10) {
+                    // Short text, no need to split
+                    textElement.append('tspan')
+                      .attr('x', 0)
+                      .attr('dy', '0em')
+                      .text(d.name);
+                  } else {
+                    // Split into two lines
+                    const middle = Math.ceil(words.length / 2);
+                    const firstLine = words.slice(0, middle).join(' ');
+                    const secondLine = words.slice(middle).join(' ');
+                    textElement.append('tspan')
+                      .attr('x', 0)
+                      .attr('dy', '-0.4em') // Move first line up
+                      .text(firstLine);
+                    textElement.append('tspan')
+                      .attr('x', 0)
+                      .attr('dy', '1.2em') // Move second line down
+                      .text(secondLine);
+                  }
+                });
+              }),
         (update) => update,
         (exit) => exit
           .transition()


### PR DESCRIPTION
Changing the interface so that the nodes do not bounce back when they are moved by the user. 
Also, the text is now compacted so that all of it is visible. Minimum font size would b 8 for this.

<img width="764" alt="image" src="https://github.com/user-attachments/assets/22a0a2ef-525e-478c-9aaa-819d87fbf12e" />
