### PR TITLE
Bugfix/hot reload

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ You may also directly invoke docker-compose with the following command:
 docker-compose -f docker-compose.base.yml -f docker-compose.dev.yml up --build
 ```
 
+> **Note:** For hot reloading during development, make sure to use `http://localhost:8080` to access the application. Accessing the app via `http://localhost:7080` will serve the non-reloading version.
+
 ## Deployment
 
 Deploy using the following command (recommended):

--- a/package.json
+++ b/package.json
@@ -97,8 +97,7 @@
   },
   "scripts": {
     "start": "webpack --mode=development --config webpack.dev.js && nodemon server.js",
-    "dev": "concurrently \"webpack --watch --config webpack.dev.js\" \"nodemon server.js\"",
-    "hot-reload": "concurrently \"HOT_RELOAD=true webpack-dev-server --watch --config webpack.dev.js\" \"nodemon server.js\"",
+    "dev":  "concurrently \"HOT_RELOAD=true webpack-dev-server --watch --config webpack.dev.js\" \"nodemon server.js\"",
     "prod": "webpack --mode=production --config webpack.prod.js && node server.js",
     "lint": "eslint src/",
     "lint-summary": "eslint -f summary src/",

--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
   "scripts": {
     "start": "webpack --mode=development --config webpack.dev.js && nodemon server.js",
     "dev": "concurrently \"webpack --watch --config webpack.dev.js\" \"nodemon server.js\"",
-    "hot-reload": "HOT_RELOAD=true webpack-dev-server --watch --config webpack.dev.js",
+    "hot-reload": "concurrently \"HOT_RELOAD=true webpack-dev-server --watch --config webpack.dev.js\" \"nodemon server.js\"",
     "prod": "webpack --mode=production --config webpack.prod.js && node server.js",
     "lint": "eslint src/",
     "lint-summary": "eslint -f summary src/",

--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -11,9 +11,12 @@ module.exports = merge(common, {
     historyApiFallback: true,
     disableHostCheck: true,
     host: '0.0.0.0',
-    port: process.env.QGRAPH_PORT,
+    port: 8080,
     hot: hotReload,
     inline: hotReload,
+    proxy: {
+      '/api': 'http://localhost:7080',
+    },
   },
   devtool: 'cheap-module-eval-source-map',
   mode: 'development',


### PR DESCRIPTION
- Fixed hot reload issue.
- `npm run dev` now uses hot reload.
- React app runs in port 8080 (http://localhost:8080) while the nodejs server runs in port 7080.
- Added a proxy to redirect all the API calls to port 7080 in the dev webpack